### PR TITLE
add compatibility with draft table schema

### DIFF
--- a/pysqlar/archive.py
+++ b/pysqlar/archive.py
@@ -35,6 +35,17 @@ CREATE TABLE sqlar(
 """The table definition for the SQLite Archive table."""
 
 
+SQLAR_DRAFT_TABLE_SCHEMA = " ".join("""
+CREATE TABLE sqlar(
+    name TEXT PRIMARY KEY, -- name of the file
+    mode INT, -- access permissions
+    mtime INT, -- last modification time
+    sz INT, -- original file size
+    data BLOB -- compressed content
+)""".split()) # Normalize whitespace in the statement
+"""The draft table definition for the SQLite Archive table."""
+
+
 class SQLiteArchiveException(Exception):
     pass
 
@@ -144,7 +155,7 @@ def _sqlar_table_exists(conn):
         # Normalize whitespace
         sql = " ".join(sql.split())
         logger.debug(sql)
-        if sql == SQLAR_TABLE_SCHEMA:
+        if sql == SQLAR_TABLE_SCHEMA or sql == SQLAR_DRAFT_TABLE_SCHEMA:
             return True
 
     return False


### PR DESCRIPTION
Hello,

Thanks for making this cool python package!

I was running into an issue with reading from a sqlite3 archive I made using the sqlite3 CLI:

```
#!/usr/bin/env python3

import logging
from pysqlar import SQLiteArchive

logging.basicConfig(filename='example.log', encoding='utf-8', level=logging.DEBUG)

with SQLiteArchive('/Users/bwingfield/Downloads/example.sqlar', 'ro') as ar:
    pass

```

Returns an exception:

```
pysqlar.archive.SQLiteArchiveException: /Users/bwingfield/Downloads/example.sqlar is not a sqlite archive
```

I think the table definition may have changed. Debug log:

```
DEBUG:pysqlar.archive:CREATE TABLE sqlar( name TEXT PRIMARY KEY, -- name of the file mode INT, -- access permissions mtime INT, -- last modification time sz INT, -- original file size data BLOB -- compressed content )
```

Which is different to [`SQLAR_TABLE_SCHEMA`](https://github.com/Frojdholm/pysqlar/blob/57829ffde9492913cb351833b6ba675cf48a9ed0/pysqlar/archive.py#L27)

```
CREATE TABLE sqlar(
    name TEXT PRIMARY KEY,
    mode INT,
    mtime INT,
    sz INT,
    data BLOB
)
```

It looks like the table definition has been updated in the latest draft: https://www.sqlite.org/draft/sqlar.html 

This pull request fixes  the issue for me 😁 

Thanks!
